### PR TITLE
add bower install to the ci script + make the line readable

### DIFF
--- a/bin/ci
+++ b/bin/ci
@@ -1,2 +1,10 @@
 #!/bin/bash
-node_modules/mocha/bin/mocha test/*.coffee test/**/*.coffee --require should --require test/test_helpers.coffee --compilers coffee:coffee-script && cd client && npm install && node_modules/grunt-cli/bin/grunt && node_modules/karma/bin/karma start --single-run --browsers Safari
+node_modules/mocha/bin/mocha test/*.coffee test/**/*.coffee \
+	--require should \
+	--require test/test_helpers.coffee \
+	--compilers coffee:coffee-script && \
+	cd client && \
+	npm install && \
+	node_modules/bower/bin/bower install && \
+	node_modules/grunt-cli/bin/grunt && \
+	node_modules/karma/bin/karma start --single-run --browsers Safari


### PR DESCRIPTION
and I was wondering, why the microevent lib was not being compiled into the resulting js file... bower install was missing. also make it a bit more readable
