### PR TITLE
fix takana-client/dist path to work for both local and global installs

### DIFF
--- a/lib/server.coffee
+++ b/lib/server.coffee
@@ -16,6 +16,7 @@ shell           = require 'shelljs'
 path            = require 'path'
 express         = require 'express'
 _               = require 'underscore'
+fs              = require 'fs'
 
 # configuration options
 Config = 
@@ -65,7 +66,13 @@ class Server
   
   setupWebServer: ->
     # serve the client side JS for browsers that listen to live updates
-    @app.use express.static(path.join(__dirname, '..', '/node_modules/takana-client/dist'))
+    try
+      takanaClientDistPath = path.join(__dirname, '../../..', '/node_modules/takana-client/dist')
+      fs.accessSync(takanaClientDistPath)
+    catch
+      takanaClientDistPath = path.join(__dirname, '..', '/node_modules/takana-client/dist')
+
+    @app.use express.static(takanaClientDistPath)
     @app.use express.json()
     @app.use express.urlencoded()
 


### PR DESCRIPTION
0.5.2 worked for gulp, but broke CLI
0.5.3 fixed CLI, but broke takana in gulp.

Unfortunately, this is due to the location difference of takana-client when takana is installed locally vs globally.

Local install paths:
node_modules/takana/lib/server.coffee
node_modules/takana-client

Global install paths:
node_modules/takana/lib/server.coffee
node_modules/takana/node_modules/takana-client

The following commit handles both cases, checking first for a local install.